### PR TITLE
Implement Bank Connector MVP service

### DIFF
--- a/bank_connector/__init__.py
+++ b/bank_connector/__init__.py
@@ -1,0 +1,1 @@
+from .main import app

--- a/bank_connector/db.py
+++ b/bank_connector/db.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from sqlmodel import Field, SQLModel, create_engine, Session, select
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./bank_connector.db")
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+class SweepOrder(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    order_id: str
+    amount: float
+    currency: str
+    debtor: str
+    creditor: str
+    status: Optional[str] = None
+
+
+def init_db() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Session:
+    return Session(engine)

--- a/bank_connector/iso20022.py
+++ b/bank_connector/iso20022.py
@@ -1,0 +1,25 @@
+"""Helpers to build and parse ISO20022 messages using pydantic_xsd."""
+
+from pydantic_xsd import BaseModel
+
+
+class Pain001(BaseModel, xsd_path="urn:iso:std:iso:20022:tech:xsd:pain.001.001.09.xsd"):
+    pass  # actual fields provided by schema
+
+
+class Pain002(BaseModel, xsd_path="urn:iso:std:iso:20022:tech:xsd:pain.002.001.10.xsd"):
+    pass
+
+
+def create_pain_001(order_id: str, amount: float, currency: str, debtor: str, creditor: str) -> str:
+    """Return XML string for pain.001 message."""
+    msg = Pain001.parse_obj({})  # placeholder since schema models provide defaults
+    # In real implementation you'd populate fields accordingly
+    return msg.to_xml()
+
+
+def parse_pain_002(xml: str) -> str:
+    """Parse pain.002 XML and return payment status."""
+    msg = Pain002.from_xml(xml)
+    # In real implementation you'd access proper status field
+    return getattr(msg, "status", "UNKNOWN")

--- a/bank_connector/main.py
+++ b/bank_connector/main.py
@@ -1,0 +1,53 @@
+import os
+from fastapi import FastAPI, Response, Depends, Request
+import httpx
+from sqlmodel import Session, select
+
+from .db import SweepOrder, init_db, get_session
+from .models import SweepOrderRequest, PaymentStatusResponse
+from .iso20022 import create_pain_001, parse_pain_002
+
+app = FastAPI()
+
+init_db()
+
+BANK_API_URL = os.getenv("BANK_API_URL", "http://localhost:9999")
+
+
+@app.post("/sweep-order")
+async def create_sweep_order(payload: SweepOrderRequest, session: Session = Depends(get_session)):
+    xml = create_pain_001(
+        payload.order_id, payload.amount, payload.currency, payload.debtor, payload.creditor
+    )
+    async with httpx.AsyncClient() as client:
+        await client.post(BANK_API_URL, data=xml, headers={"Content-Type": "application/xml"})
+
+    order = SweepOrder(
+        order_id=payload.order_id,
+        amount=payload.amount,
+        currency=payload.currency,
+        debtor=payload.debtor,
+        creditor=payload.creditor,
+        status="SENT",
+    )
+    session.add(order)
+    session.commit()
+    session.refresh(order)
+    return {"id": order.id}
+
+
+@app.post("/payment-status")
+async def payment_status(request: Request, session: Session = Depends(get_session)) -> PaymentStatusResponse:
+    xml = await request.body()
+    status = parse_pain_002(xml.decode())
+    order_id = request.headers.get("X-Order-ID")
+    result = (
+        session.exec(select(SweepOrder).where(SweepOrder.order_id == order_id)).first()
+        if order_id
+        else None
+    )
+    if result:
+        result.status = status
+        session.add(result)
+        session.commit()
+    return PaymentStatusResponse(status=status)

--- a/bank_connector/models.py
+++ b/bank_connector/models.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class SweepOrderRequest(BaseModel):
+    order_id: str
+    amount: float
+    currency: str
+    debtor: str
+    creditor: str
+
+
+class PaymentStatusResponse(BaseModel):
+    status: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,23 @@ version = "0.1.0"
 description = "Treasury Orchestrator for Bankers Bank"
 authors = ["Your Name <your.email@example.com>"]
 readme = "README.md"
-packages = [{include = "treasury_orchestrator"}]
+packages = [
+    {include = "treasury_orchestrator"},
+    {include = "bank_connector"},
+]
 
 [tool.poetry.dependencies]
 python = "^3.8"
 pydantic = "^2.0"
+fastapi = "^0.110"
+httpx = "^0.27"
+sqlmodel = "^0.0.16"
+pydantic-xsd = "^0.3.2"
+uvicorn = "^0.29"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"
+requests-mock = "^1.11"
 black = "^23.0"
 isort = "^5.0"
 mypy = "^1.0"

--- a/tests/test_bank_connector.py
+++ b/tests/test_bank_connector.py
@@ -1,0 +1,31 @@
+import json
+import pytest
+from fastapi.testclient import TestClient
+
+from bank_connector.main import app
+
+
+def test_post_sweep_order(requests_mock):
+    requests_mock.post("http://localhost:9999", text="<ok/>")
+    client = TestClient(app)
+    payload = {
+        "order_id": "123",
+        "amount": 10.0,
+        "currency": "USD",
+        "debtor": "Alice",
+        "creditor": "Bob",
+    }
+    resp = client.post("/sweep-order", json=payload)
+    assert resp.status_code == 200
+
+
+def test_payment_status(requests_mock):
+    xml = "<pain.002></pain.002>"
+    requests_mock.post("http://localhost:9999", text="<ok/>")
+    client = TestClient(app)
+    client.post(
+        "/sweep-order",
+        json={"order_id": "abc", "amount": 1, "currency": "USD", "debtor": "A", "creditor": "B"},
+    )
+    resp = client.post("/payment-status", data=xml, headers={"X-Order-ID": "abc"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add FastAPI-based bank_connector app for posting sweep orders and payment status
- generate ISO20022 messages with pydantic-xsd placeholders
- persist sweep orders using SQLModel and env-configured database
- define tests using requests-mock
- include dependencies for FastAPI, httpx, SQLModel, pydantic-xsd

## Testing
- `pip install requests httpx fastapi sqlmodel pydantic-xsd uvicorn pytest requests-mock --quiet` *(fails: Tunnel connection failed)*
- `pytest tests/test_bank_connector.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_687ea24be7ec832bb73e7c2cf53e2ebe