### PR TITLE
Implement CreditFacilityService

### DIFF
--- a/tests/test_credit_service.py
+++ b/tests/test_credit_service.py
@@ -1,0 +1,58 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import httpx
+from sqlmodel import SQLModel, create_engine, Session, select
+
+from treasury_orchestrator.credit_db import CreditFacility, CreditTxn
+from treasury_orchestrator.credit import CreditFacilityService, JpmLiquidityClient
+from bankersbank.finastra import FinastraAPIClient
+
+
+def setup_session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    return Session(engine)
+
+
+def test_refresh_capacity(monkeypatch):
+    session = setup_session()
+    fac = CreditFacility(id="fac1", limit=100000, drawn=0, ltv_limit=0.5)
+    session.add(fac)
+    session.commit()
+
+    fin = FinastraAPIClient(token="dummy")
+    monkeypatch.setattr(fin, "collaterals_for_account", lambda _: {"items": [{"valuation": 200000}]})
+    jpm = JpmLiquidityClient("http://jpm", "id", "sec", "http://token")
+
+    service = CreditFacilityService(fac, fin, jpm, session)
+    asyncio.run(service.refresh_capacity())
+    assert service.available == 50000
+
+
+def test_draw_creates_txn(monkeypatch):
+    session = setup_session()
+    fac = CreditFacility(id="fac2", limit=50000, drawn=0, ltv_limit=1.0)
+    session.add(fac)
+    session.commit()
+
+    fin = FinastraAPIClient(token="dummy")
+    monkeypatch.setattr(fin, "collaterals_for_account", lambda _: {"items": [{"valuation": 50000}]})
+
+    async def fake_post(url, data=None, json=None, headers=None):
+        if "token" in url:
+            return httpx.Response(status_code=200, json={"access_token": "tok"})
+        return httpx.Response(status_code=201)
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", AsyncMock(side_effect=fake_post))
+
+    jpm = JpmLiquidityClient("http://jpm", "id", "sec", "http://token")
+    service = CreditFacilityService(fac, fin, jpm, session)
+    asyncio.run(service.refresh_capacity())
+    asyncio.run(service.draw(20000, "USD"))
+
+    assert fac.drawn == 20000
+    txns = session.exec(select(CreditTxn)).all()
+    assert len(txns) == 1
+    assert txns[0].txn_type == "DRAW"
+

--- a/treasury_orchestrator/credit.py
+++ b/treasury_orchestrator/credit.py
@@ -1,0 +1,111 @@
+import asyncio
+from typing import Optional
+
+import httpx
+try:  # pragma: no cover - optional dependency
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+except Exception:  # pragma: no cover - APScheduler missing
+    AsyncIOScheduler = None
+from sqlmodel import Session
+
+from bankersbank.finastra import FinastraAPIClient
+
+from .credit_db import CreditFacility, CreditTxn
+
+
+class JpmLiquidityClient:
+    """Minimal JPM liquidity adapter using OAuth2 client credentials."""
+
+    def __init__(self, base_url: str, client_id: str, client_secret: str, token_url: str):
+        self.base_url = base_url.rstrip("/")
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.token_url = token_url
+        self._token: Optional[str] = None
+
+    async def token(self) -> str:
+        if self._token:
+            return self._token
+        data = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(self.token_url, data=data)
+            resp.raise_for_status()
+            self._token = resp.json()["access_token"]
+        return self._token
+
+    async def _headers(self) -> dict:
+        return {"Authorization": f"Bearer {await self.token()}"}
+
+    async def post_draw(self, amount: float, currency: str) -> httpx.Response:
+        url = f"{self.base_url}/draw"
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, json={"amount": amount, "currency": currency}, headers=await self._headers())
+            resp.raise_for_status()
+            return resp
+
+    async def post_repay(self, amount: float) -> httpx.Response:
+        url = f"{self.base_url}/repay"
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, json={"amount": amount}, headers=await self._headers())
+            resp.raise_for_status()
+            return resp
+
+
+class CreditFacilityService:
+    """Business logic for managing a credit facility."""
+
+    def __init__(self, facility: CreditFacility, fin_client: FinastraAPIClient, jpm_client: JpmLiquidityClient, session: Session):
+        self.facility = facility
+        self.fin_client = fin_client
+        self.jpm_client = jpm_client
+        self.session = session
+        self.available: float = 0.0
+        self.scheduler: Optional[AsyncIOScheduler] = None
+
+    async def refresh_capacity(self) -> float:
+        """Update available capacity based on collateral valuation."""
+        data = self.fin_client.collaterals_for_account(self.facility.id)
+        total = sum(float(c.get("valuation", 0)) for c in data.get("items", []))
+        capacity = min(self.facility.limit, total * self.facility.ltv_limit)
+        self.available = max(0.0, capacity - self.facility.drawn)
+        return self.available
+
+    async def draw(self, amount: float, currency: str = "USD") -> CreditTxn:
+        if amount > self.available:
+            raise ValueError("Insufficient capacity")
+        await self.jpm_client.post_draw(amount, currency)
+        self.facility.drawn += amount
+        txn = CreditTxn(facility_id=self.facility.id, amount=amount, txn_type="DRAW")
+        self.session.add(self.facility)
+        self.session.add(txn)
+        self.session.commit()
+        await self.refresh_capacity()
+        return txn
+
+    async def repay(self, amount: float) -> CreditTxn:
+        await self.jpm_client.post_repay(amount)
+        self.facility.drawn = max(0.0, self.facility.drawn - amount)
+        txn = CreditTxn(facility_id=self.facility.id, amount=amount, txn_type="REPAY")
+        self.session.add(self.facility)
+        self.session.add(txn)
+        self.session.commit()
+        await self.refresh_capacity()
+        return txn
+
+    def start_scheduler(self) -> None:
+        if AsyncIOScheduler is None:
+            raise RuntimeError("APScheduler not installed")
+        scheduler = AsyncIOScheduler()
+        scheduler.add_job(
+            lambda: asyncio.create_task(self.refresh_capacity()),
+            "interval",
+            seconds=900,
+        )
+        scheduler.start()
+        self.scheduler = scheduler
+
+

--- a/treasury_orchestrator/credit_db.py
+++ b/treasury_orchestrator/credit_db.py
@@ -1,0 +1,36 @@
+import os
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, Session, SQLModel, create_engine
+
+DATABASE_URL = os.getenv("CREDIT_DB_URL", "sqlite:///./credit_facility.db")
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+class CreditFacility(SQLModel, table=True):
+    """Credit facility master record."""
+
+    id: str = Field(primary_key=True)
+    limit: float
+    drawn: float = 0.0
+    ltv_limit: float
+
+
+class CreditTxn(SQLModel, table=True):
+    """Individual credit facility transactions."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    facility_id: str = Field(foreign_key="creditfacility.id")
+    amount: float
+    txn_type: str
+    ts: datetime = Field(default_factory=datetime.utcnow)
+
+
+def init_db() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Session:
+    return Session(engine)
+


### PR DESCRIPTION
## Summary
- add SQLModel tables for credit facilities and transactions
- implement JPM liquidity client and credit facility service
- schedule periodic capacity refresh if APScheduler is available
- test credit facility behaviour with mocked Finastra SDK and JPM posts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687fb87b703c832ba43167df3beca8d4