### PR TITLE
Fix test utilities for integration suite

### DIFF
--- a/integration-client/test_finastra_integration.py
+++ b/integration-client/test_finastra_integration.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pytest
 import json
+import requests
 from tests.test_helpers import JSONSCHEMA_AVAILABLE, REQUESTS_AVAILABLE
 
 if JSONSCHEMA_AVAILABLE:

--- a/integration-client/test_ltv_integration.py
+++ b/integration-client/test_ltv_integration.py
@@ -3,6 +3,7 @@ import importlib.util
 import sys
 from pathlib import Path
 import pytest
+import requests
 
 from tests.test_helpers import REQUESTS_AVAILABLE
 from test_helpers import clear_collateral_registry

--- a/integration-client/test_negative_cases.py
+++ b/integration-client/test_negative_cases.py
@@ -2,6 +2,7 @@ import pytest
 import importlib.util
 import sys
 from pathlib import Path
+import requests
 
 from tests.test_helpers import REQUESTS_AVAILABLE
 from test_helpers import clear_collateral_registry

--- a/integration-client/test_sdk.py
+++ b/integration-client/test_sdk.py
@@ -1,4 +1,5 @@
 from tests.test_helpers import *
+from integration_client.utils import clear_collateral_registry
 import sys
 from pathlib import Path
 import pytest

--- a/integration_client/__init__.py
+++ b/integration_client/__init__.py
@@ -1,0 +1,1 @@
+"""Test utilities package for integration-client"""

--- a/integration_client/utils.py
+++ b/integration_client/utils.py
@@ -1,0 +1,10 @@
+"""
+Shared test utilities for integration-client suite
+"""
+# simple global list referenced by SDK or mock (import path adjust if needed)
+from bankersbank.client import _COLLATERAL_REGISTRY
+
+
+def clear_collateral_registry() -> None:
+    """Reset collateral registry between tests."""
+    _COLLATERAL_REGISTRY.clear()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,6 +11,7 @@ except Exception:
     stub.get = stub.post = _stub
     import sys
     sys.modules["requests"] = stub
+    requests = stub
 
 try:
     import jsonschema  # type: ignore
@@ -23,3 +24,5 @@ except Exception:
     js_stub.validate = _js_stub
     import sys
     sys.modules["jsonschema"] = js_stub
+
+__all__ = ["REQUESTS_AVAILABLE", "requests", "JSONSCHEMA_AVAILABLE"]


### PR DESCRIPTION
## Summary
- add utilities package with `clear_collateral_registry`
- import helper in integration tests
- expose `requests` via tests helpers
- add explicit `requests` imports in integration tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for requests and other deps)*

------
https://chatgpt.com/codex/tasks/task_e_687fd8803d14832baffa9eccbe8519db