### PR TITLE
Fix integration tests setup

### DIFF
--- a/integration-client/test_finastra_integration.py
+++ b/integration-client/test_finastra_integration.py
@@ -1,9 +1,9 @@
 
+import requests
 import sys
 from pathlib import Path
 import pytest
 import json
-import requests
 from tests.test_helpers import JSONSCHEMA_AVAILABLE, REQUESTS_AVAILABLE
 
 if JSONSCHEMA_AVAILABLE:

--- a/integration-client/test_ltv_integration.py
+++ b/integration-client/test_ltv_integration.py
@@ -1,9 +1,9 @@
+import requests
 import uuid
 import importlib.util
 import sys
 from pathlib import Path
 import pytest
-import requests
 
 from tests.test_helpers import REQUESTS_AVAILABLE
 from test_helpers import clear_collateral_registry

--- a/integration-client/test_negative_cases.py
+++ b/integration-client/test_negative_cases.py
@@ -1,8 +1,8 @@
+import requests
 import pytest
 import importlib.util
 import sys
 from pathlib import Path
-import requests
 
 from tests.test_helpers import REQUESTS_AVAILABLE
 from test_helpers import clear_collateral_registry

--- a/integration_client/utils.py
+++ b/integration_client/utils.py
@@ -1,10 +1,8 @@
-"""
-Shared test utilities for integration-client suite
-"""
-# simple global list referenced by SDK or mock (import path adjust if needed)
+"""Shared helpers for integration tests."""
+
 from bankersbank.client import _COLLATERAL_REGISTRY
 
 
 def clear_collateral_registry() -> None:
-    """Reset collateral registry between tests."""
+    """Reset global collateral registry between tests."""
     _COLLATERAL_REGISTRY.clear()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    enable_socket: allow tests to make network calls

--- a/sdk/python/bankersbank/client.py
+++ b/sdk/python/bankersbank/client.py
@@ -2,6 +2,12 @@ import requests
 import os
 from typing import Dict, Any
 
+try:
+    # Reuse the mock API's collateral registry when available
+    from mocks.mock_finastra_api import collateral_registry as _COLLATERAL_REGISTRY
+except Exception:  # pragma: no cover - fallback for production envs
+    _COLLATERAL_REGISTRY: list[dict] = []
+
 def _use_mock() -> bool:
     """
     Returns True if we should call the local mock server


### PR DESCRIPTION
## Summary
- expose `_COLLATERAL_REGISTRY` in SDK client
- provide helper to clear collateral registry for integration tests
- ensure integration tests import `requests`
- register the `enable_socket` mark in pytest

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687fdbe2a45c832ba87886c911d409ea