### PR TITLE
Add HighLTVRatio alert and runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
           version: v3.12.3
       - name: Install chart
         run: helm install bankers kubernetes/helm --wait --timeout 300s
+      - name: Validate alert rules
+        run: promtool test rules prom/alert.rules.yml
       - name: Check metrics endpoint
         run: |
           kubectl wait --for=condition=available --timeout=120s deployment/prometheus

--- a/docs/runbooks/ltv_breach.md
+++ b/docs/runbooks/ltv_breach.md
@@ -1,0 +1,12 @@
+# LTV Breach Runbook
+
+This runbook describes how to investigate and mitigate situations where the loan-to-value (LTV) ratio exceeds 80%.
+
+## Investigation steps
+1. **Grafana:** Check the `HighLTVRatio` alert and inspect related dashboards for sudden spikes.
+2. **Aggregator logs:** Review logs from the asset aggregator service for any anomalous asset valuations.
+3. **CreditFacility draw/repay history:** Confirm recent draws or repayments on the credit facility that may have impacted the ratio.
+
+## Mitigation
+* Perform a manual repayment to bring the LTV ratio below the limit.
+* Increase posted collateral if repayment is not immediately possible.

--- a/kubernetes/helm/templates/alert-rules-cm.yaml
+++ b/kubernetes/helm/templates/alert-rules-cm.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.enableAlerting }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alert-rules
+  labels:
+    app: prometheus
+data:
+  alert.rules.yml: |
+    groups:
+    - name: treasury-alerts
+      rules:
+      - alert: HighLTVRatio
+        expr: treas_ltv_ratio / max_ltv > 0.8
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "LTV ratio above 80% for {{ $labels.bank_id }}"
+          runbook: https://github.com/zveasy/bankers-bank/docs/runbooks/ltv_breach.md
+{{- end }}

--- a/kubernetes/helm/templates/prometheus.yaml
+++ b/kubernetes/helm/templates/prometheus.yaml
@@ -21,10 +21,19 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/prometheus
+{{- if .Values.enableAlerting }}
+        - name: alert-rules
+          mountPath: /etc/prometheus-rules
+{{- end }}
       volumes:
       - name: config
         configMap:
           name: prometheus-config
+{{- if .Values.enableAlerting }}
+      - name: alert-rules
+        configMap:
+          name: alert-rules
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -34,6 +43,10 @@ data:
   prometheus.yml: |
     global:
       scrape_interval: 5s
+{{- if .Values.enableAlerting }}
+    rule_files:
+      - /etc/prometheus-rules/alert.rules.yml
+{{- end }}
     scrape_configs:
       - job_name: bankers-bank
         static_configs:

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -2,6 +2,8 @@ bank_connector:
   image: bank_connector:latest
   port: 8080
 
+enableAlerting: true
+
 treasury_orchestrator:
   image: treasury_orchestrator:latest
   port: 8000

--- a/prom/alert.rules.yml
+++ b/prom/alert.rules.yml
@@ -1,0 +1,8 @@
+alert: HighLTVRatio
+expr: treas_ltv_ratio / max_ltv > 0.8
+for: 5m
+labels:
+  severity: critical
+annotations:
+  summary: "LTV ratio above 80% for {{ $labels.bank_id }}"
+  runbook: https://github.com/zveasy/bankers-bank/docs/runbooks/ltv_breach.md


### PR DESCRIPTION
## Summary
- add Prometheus rule `HighLTVRatio`
- document runbook for LTV breaches
- configure Helm chart to mount alert rules
- enable alerting via chart values
- validate alert rules in CI

## Testing
- `poetry install --no-interaction` *(fails: All attempts to connect to pypi.org failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `go test ./...` *(fails: directory prefix . does not contain main module)*
- `promtool test rules prom/alert.rules.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68813e702698832b80045cfb5de83d1b