### PR TITLE
feat: support external redpanda access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,17 +24,21 @@ services:
     image: redpandadata/redpanda:latest
     command: >
       redpanda start
-      --overprovisioned
-      --smp 1
-      --memory 1G
-      --reserve-memory 0M
-      --node-id 0
-      --check=false
-      --kafka-addr PLAINTEXT://0.0.0.0:9092
-      --advertise-kafka-addr PLAINTEXT://127.0.0.1:9092
+        --overprovisioned
+        --smp 1
+        --memory 1G
+        --reserve-memory 0M
+        --node-id 0
+        --check=false
+        # internal (in-Docker) listener
+        --kafka-addr PLAINTEXT://0.0.0.0:9092
+        --advertise-kafka-addr PLAINTEXT://redpanda:9092
+        # external (host) listener
+        --kafka-addr OUTSIDE://0.0.0.0:9092
+        --advertise-kafka-addr OUTSIDE://localhost:29092
     ports:
-      - "9092:9092"  # Expose Kafka port to host for local producer connectivity
-      - "9644:9644"
+      - "9092:9092"   # in-Docker clients use redpanda:9092
+      - "29092:9092"  # host clients use localhost:29092
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:9644/v1/status/ready || exit 1"]
       interval: 10s


### PR DESCRIPTION
### **User description**
## Summary
- support Redpanda clients outside Docker by advertising host address
- map host port 29092 and add internal/external listeners

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement poetry-core)*

------
https://chatgpt.com/codex/tasks/task_e_68913555f360832b882d77f4d4f39357


___

### **PR Type**
Enhancement


___

### **Description**
- Configure Redpanda with dual listeners for internal/external access

- Map host port 29092 for external client connectivity

- Update advertised addresses for Docker and host environments

- Improve command formatting with proper indentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Clients"] --> B["redpanda:9092"]
  C["Host Clients"] --> D["localhost:29092"]
  B --> E["Redpanda Container"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Configure dual Kafka listeners for external access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Add dual Kafka listeners (internal PLAINTEXT and external OUTSIDE)<br> <li> Configure advertised addresses for Docker and host environments<br> <li> Map additional port 29092 for external access<br> <li> Improve command formatting and add explanatory comments</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/bankers-bank/pull/29/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+14/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

