### PR TITLE
feat: secure database urls via secret

### DIFF
--- a/kubernetes/helm/templates/bank-connector.yaml
+++ b/kubernetes/helm/templates/bank-connector.yaml
@@ -16,6 +16,8 @@ spec:
       - name: bank-connector
         image: {{ .Values.bank_connector.image }}
         envFrom:
+        - secretRef:
+            name: bankers-bank-secret
         - configMapRef:
             name: bankers-bank-env
         ports:

--- a/kubernetes/helm/templates/configmap.yaml
+++ b/kubernetes/helm/templates/configmap.yaml
@@ -5,8 +5,5 @@ metadata:
   labels:
     app: bankers-bank
 data:
-  DATABASE_URL: "postgresql://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@postgres:5432/{{ .Values.postgres.db }}"
-  ASSET_DB_URL: "postgresql://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@postgres:5432/{{ .Values.postgres.db }}"
-  CREDIT_DB_URL: "postgresql://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@postgres:5432/{{ .Values.postgres.db }}"
   KAFKA_BOOTSTRAP: "redpanda:{{ .Values.redpanda.port }}"
   REDIS_URL: "redis://redis:{{ .Values.redis.port }}/0"

--- a/kubernetes/helm/templates/quant-consumer.yaml
+++ b/kubernetes/helm/templates/quant-consumer.yaml
@@ -16,6 +16,8 @@ spec:
       - name: quant-consumer
         image: {{ .Values.quant_consumer.image }}
         envFrom:
+        - secretRef:
+            name: bankers-bank-secret
         - configMapRef:
             name: bankers-bank-env
         command: ["python", "-m", "quantengine.kafka_consumer", "redpanda:{{ .Values.redpanda.port }}"]

--- a/kubernetes/helm/templates/secret.yaml
+++ b/kubernetes/helm/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bankers-bank-secret
+  labels:
+    app: bankers-bank
+type: Opaque
+stringData:
+  DATABASE_URL: "postgresql://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@postgres:5432/{{ .Values.postgres.db }}"
+  ASSET_DB_URL: "postgresql://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@postgres:5432/{{ .Values.postgres.db }}"
+  CREDIT_DB_URL: "postgresql://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@postgres:5432/{{ .Values.postgres.db }}"

--- a/kubernetes/helm/templates/treasury-orchestrator.yaml
+++ b/kubernetes/helm/templates/treasury-orchestrator.yaml
@@ -16,6 +16,8 @@ spec:
       - name: treasury-orchestrator
         image: {{ .Values.treasury_orchestrator.image }}
         envFrom:
+        - secretRef:
+            name: bankers-bank-secret
         - configMapRef:
             name: bankers-bank-env
         ports:


### PR DESCRIPTION
## Summary
- move database URLs from ConfigMap into new Kubernetes Secret
- update Deployments to load DB URLs from Secret
- trim ConfigMap to non-sensitive entries
- revert accidental commit of `.data/quant.db`

## Testing
- `pytest` *(fails: tests/test_audit_cli.py::test_cli_runs - subprocess.CalledProcessError)*
- `helm version` *(command not found; helm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c3325ae4832bb104f9fa1ced1b90