### PR TITLE
Secure Grafana dashboard access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 POSTGRES_USER=bank
 POSTGRES_PASSWORD=bank
 POSTGRES_DB=bank
+
+# Grafana admin credentials (change for your environment)
+GF_ADMIN_USER=admin
+GF_ADMIN_PASSWORD=changeme

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ start http://localhost:9000/docs  # Asset Aggregator
 docker compose down -v
 ```
 
+### Grafana dashboards
+
+Grafana runs with authentication enabled and is only bound to `localhost` to
+avoid exposing dashboards beyond internal networks.
+
+1.  Set credentials in `.env`:
+
+    ```bash
+    GF_ADMIN_USER=admin
+    GF_ADMIN_PASSWORD=changeme
+    ```
+
+2.  Start the stack with `docker compose up`.
+3.  Browse to [http://localhost:3000](http://localhost:3000) and log in with the
+    credentials above.
+4.  Do not publish the Grafana port publicly without additional network
+    protections (VPN, firewall, etc.).
+
 ### Health & smoke
 
 - Health endpoints:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,9 +227,11 @@ services:
 
   grafana:
     image: grafana/grafana:latest
-    ports: ["3000:3000"]
+    ports: ["127.0.0.1:3000:3000"]
     environment:
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_SECURITY_ADMIN_USER: ${GF_ADMIN_USER}
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD}
     volumes:
       - ./grafana/dashboards:/var/lib/grafana/dashboards
       - ./grafana/provisioning:/etc/grafana/provisioning


### PR DESCRIPTION
### **User description**
## Summary
- Disable anonymous Grafana access
- Bind Grafana UI to localhost and require admin credentials
- Document Grafana login steps and emphasize internal-only exposure

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4c6e30930832b9c17d1347b29fffc


___

### **PR Type**
Enhancement


___

### **Description**
- Disable anonymous Grafana access and require authentication

- Bind Grafana to localhost only for security

- Add admin credentials configuration via environment variables

- Document secure Grafana setup and access instructions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Anonymous Access"] --> B["Authenticated Access"]
  C["Public Port Binding"] --> D["Localhost Only Binding"]
  E["Environment Variables"] --> F["Admin Credentials"]
  B --> G["Secure Grafana Dashboard"]
  D --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.example</strong><dd><code>Add Grafana admin credentials configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.env.example

<ul><li>Add <code>GF_ADMIN_USER</code> and <code>GF_ADMIN_PASSWORD</code> environment variables<br> <li> Include comment about changing credentials for production</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/bankers-bank/pull/56/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Secure Grafana service configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Change port binding from public to localhost only <br>(<code>127.0.0.1:3000:3000</code>)<br> <li> Disable anonymous authentication (<code>GF_AUTH_ANONYMOUS_ENABLED: "false"</code>)<br> <li> Add admin user and password environment variables</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/bankers-bank/pull/56/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document secure Grafana access setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add new "Grafana dashboards" section with setup instructions<br> <li> Document authentication requirements and localhost binding<br> <li> Include security warning about public exposure<br> <li> Provide step-by-step login process</ul>


</details>


  </td>
  <td><a href="https://github.com/zveasy/bankers-bank/pull/56/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

