### PR TITLE
Make SnapshotRequest.bank_id optional

### DIFF
--- a/asset_aggregator/api.py
+++ b/asset_aggregator/api.py
@@ -36,7 +36,7 @@ app.mount("/metrics", make_asgi_app())
 
 
 class SnapshotRequest(BaseModel):
-    bank_id: str | None = none
+    bank_id: str | None = None
 
 
 @app.get("/healthz", response_model=dict)

--- a/tests/test_asset_aggregator_api.py
+++ b/tests/test_asset_aggregator_api.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sys
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlmodel import SQLModel
+
+
+@pytest.fixture()
+def client_api(monkeypatch: pytest.MonkeyPatch):
+    db_url = "sqlite:///./test_asset_api.db"
+    monkeypatch.setenv("ASSET_DB_URL", db_url)
+    SQLModel.metadata.clear()
+    sys.modules.pop("asset_aggregator.db", None)
+    sys.modules.pop("asset_aggregator.api", None)
+    import asset_aggregator.api as api
+    monkeypatch.setattr(api, "reconcile_snapshot", lambda *args, **kwargs: None)
+    return TestClient(api.app), api
+
+
+def test_snapshot_accepts_explicit_bank_id(client_api, monkeypatch: pytest.MonkeyPatch):
+    client, api = client_api
+    captured: dict[str, str | None] = {}
+
+    def fake_run_snapshot_once(bank_id: str | None):
+        captured["bank_id"] = bank_id
+        return ("ok", 0.1)
+
+    monkeypatch.setattr(api, "run_snapshot_once", fake_run_snapshot_once)
+    resp = client.post(
+        "/snapshot", params={"bank_id": "B1"}, headers={"Authorization": "Bearer testtoken"}
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["bank_id"] == "B1"
+
+
+def test_snapshot_accepts_missing_bank_id(client_api, monkeypatch: pytest.MonkeyPatch):
+    client, api = client_api
+    captured: dict[str, str | None] = {}
+
+    def fake_run_snapshot_once(bank_id: str | None):
+        captured["bank_id"] = bank_id
+        return ("ok", 0.1)
+
+    monkeypatch.setattr(api, "run_snapshot_once", fake_run_snapshot_once)
+    resp = client.post("/snapshot", headers={"Authorization": "Bearer testtoken"})
+    assert resp.status_code == 200, resp.text
+    assert captured["bank_id"] == "O&L"


### PR DESCRIPTION
## Summary
- fix SnapshotRequest default to None so API handles missing bank_id
- add tests ensuring /snapshot endpoint accepts explicit and missing bank_id values

## Testing
- `pytest tests/test_asset_aggregator_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b09207bfd0832ba50f8650d397a5e9