### PR TITLE
chore: pin docker image versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     restart: unless-stopped
 
   redpanda:
-    image: redpandadata/redpanda:latest
+    # Pin Redpanda to a specific version to avoid unexpected upgrades
+    image: redpandadata/redpanda:v23.3.2
     command: >
       redpanda start \
         --overprovisioned \
@@ -62,7 +63,7 @@ services:
   # Mock external bank (for /sweep-order)
   # ────────────────────────────────
   mock_bank:
-    image: mccutchen/go-httpbin:latest   # lightweight httpbin
+    image: mccutchen/go-httpbin:v2.10.0   # lightweight httpbin, pinned
     expose:
       - "8080"
     restart: unless-stopped
@@ -226,7 +227,8 @@ services:
         condition: service_started
 
   grafana:
-    image: grafana/grafana:latest
+    # Pin Grafana dashboard version
+    image: grafana/grafana:10.4.3
     ports: ["127.0.0.1:3000:3000"]
     environment:
       GF_AUTH_ANONYMOUS_ENABLED: "false"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.3] - 2025-08-28
+
+### Changed
+
+* Pinned Docker images to specific versions in `docker-compose.yml`:
+  * `redpandadata/redpanda:v23.3.2`
+  * `mccutchen/go-httpbin:v2.10.0`
+  * `grafana/grafana:10.4.3`
+
 ## [0.2.2] - 2025-07-06
 
 ### Added


### PR DESCRIPTION
## Summary
- pin all services using `:latest` tags to explicit versions in `docker-compose.yml`
- note pinned versions in changelog

## Testing
- `pytest`
- `docker compose up -d` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b093ebcdd8832bb33ffac145dd2e42