### PR TITLE
Configure ingress host and paths

### DIFF
--- a/kubernetes/helm/templates/ingress.yaml
+++ b/kubernetes/helm/templates/ingress.yaml
@@ -4,13 +4,20 @@ metadata:
   name: bankers-bank
 spec:
   rules:
-  # TODO: configure host and paths
-  - http:
+  - host: {{ .Values.ingress.host }}
+    http:
       paths:
-      - path: /
+      - path: {{ .Values.bank_connector.path }}
         pathType: Prefix
         backend:
           service:
             name: bank-connector
             port:
               number: {{ .Values.bank_connector.port }}
+      - path: {{ .Values.treasury_orchestrator.path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: treasury-orchestrator
+            port:
+              number: {{ .Values.treasury_orchestrator.port }}

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -1,13 +1,18 @@
 # Values support envsubst; see `.env.example` for local configuration.
+ingress:
+  host: bankers-bank.local
+
 bank_connector:
   image: bank_connector:latest
   port: 8080
+  path: /
 
 enableAlerting: true
 
 treasury_orchestrator:
   image: treasury_orchestrator:latest
   port: 8000
+  path: /treasury
 
 quant_consumer:
   image: quant_consumer:latest


### PR DESCRIPTION
## Summary
- define ingress host and HTTP paths for bank-connector and treasury-orchestrator services
- expose `ingress.host` and per-service path settings in Helm values

## Testing
- `helm lint kubernetes/helm` *(fails: helm not installed and installation blocked by repository restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b09558f8bc832b8dd46189406fd38b