### PR TITLE
Switch Python SDK client prints to logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ print(accounts)
 
 ```
 
+### Enable SDK logging
+
+The SDK emits debug-level logs with HTTP status codes and responses. To
+surface these logs in your application, configure Python's logging module:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+```
+
 ## Mock API Endpoints
 
 > For local dev/testing without live Finastra sandbox, see:

--- a/sdk/python/bankersbank/client.py
+++ b/sdk/python/bankersbank/client.py
@@ -1,12 +1,14 @@
 import os
+import logging
 from typing import Any, Dict
 
 import requests
 
+logger = logging.getLogger(__name__)
+
 try:
     # Reuse the mock API's collateral registry when available
-    from mocks.mock_finastra_api import \
-        collateral_registry as _COLLATERAL_REGISTRY
+    from mocks.mock_finastra_api import collateral_registry as _COLLATERAL_REGISTRY
 except Exception:  # pragma: no cover - fallback for production envs
     _COLLATERAL_REGISTRY: list[dict] = []
 
@@ -43,8 +45,8 @@ class BankersBankClient:
         params = {"accountContext": account_context}
         kwargs = {"verify": self.verify} if self.verify is not True else {}
         resp = requests.get(url, params=params, headers=self._headers(), **kwargs)
-        print("Status:", resp.status_code)
-        print("Content:", resp.text)
+        logger.debug("Status: %s", resp.status_code)
+        logger.debug("Content: %s", resp.text)
         resp.raise_for_status()
         return resp.json()
 
@@ -61,8 +63,8 @@ class BankersBankClient:
             )
         kwargs = {"verify": self.verify} if self.verify is not True else {}
         resp = requests.get(url, headers=self._headers(), **kwargs)
-        print("Status:", resp.status_code)
-        print("Content:", resp.text)
+        logger.debug("Status: %s", resp.status_code)
+        logger.debug("Content: %s", resp.text)
         resp.raise_for_status()
         return resp.json()
 
@@ -92,16 +94,16 @@ class BankersBankClient:
     def add_collateral(self, collateral_data):
         url = f"{self.base_url}/collateral"
         resp = requests.post(url, json=collateral_data, headers=self._headers())
-        print(f"Status: {resp.status_code}")
-        print(f"Content: {resp.text}")
+        logger.debug("Status: %s", resp.status_code)
+        logger.debug("Content: %s", resp.text)
         resp.raise_for_status()
         return resp.json()
 
     def get_collateral(self):
         url = f"{self.base_url}/collateral"
         resp = requests.get(url, headers=self._headers())
-        print(f"Status: {resp.status_code}")
-        print(f"Content: {resp.text}")
+        logger.debug("Status: %s", resp.status_code)
+        logger.debug("Content: %s", resp.text)
         resp.raise_for_status()
         return resp.json()
 


### PR DESCRIPTION
## Summary
- use a module logger and debug logs instead of print statements in Python SDK client
- document how to enable SDK logging in the README

## Testing
- `python -m black sdk/python/bankersbank/client.py`
- `pytest tests/unit` *(fails: ModuleNotFoundError: No module named 'bankersbank.client')*


------
https://chatgpt.com/codex/tasks/task_e_68b09d084b84832ba668da0f852ac072